### PR TITLE
dockerfile and wrapper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.project
+.history/

--- a/.gitignore/.gitignore
+++ b/.gitignore/.gitignore
@@ -1,1 +1,0 @@
-.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+
+FROM openjdk:8-jre-alpine
+
+# Expose ports
+EXPOSE 80
+
+# Add tags
+LABEL \
+  maintainer="The Petals team" \
+  contributors="Pierre Souquet (Linagora), Vincent Zurczak (Linagora)" \
+  github="https://github.com/petalslink"
+
+# Build arguments
+ARG CLI_VERSION="LATEST"
+ARG MAVEN_POLICY="releases"
+ARG BASE_URL="https://repository.ow2.org/nexus/service/local/artifact/maven/redirect"
+
+# Copy the script (first)
+COPY docker-wrapper.sh /opt/petals-deployer/docker-wrapper.sh
+
+RUN apk add --no-cache --virtual .bootstrap-deps wget ca-certificates && \
+  wget --progress=bar:force:noscroll -O /tmp/petals-cli-distrib.zip "${BASE_URL}?g=org.ow2.petals&r=${MAVEN_POLICY}&a=petals-cli-distrib-zip&v=${CLI_VERSION}&p=zip" && \
+  wget --progress=bar:force:noscroll -O /tmp/petals-cli-distrib.zip.sha1 "${BASE_URL}?g=org.ow2.petals&r=${MAVEN_POLICY}&a=petals-cli-distrib-zip&v=${CLI_VERSION}&p=zip.sha1" && \
+  [ `sha1sum /tmp/petals-cli-distrib.zip | cut -d" " -f1` = `cat /tmp/petals-cli-distrib.zip.sha1` ] && \
+  mkdir /tmp/petals-cli-distrib-zip && \
+  unzip /tmp/petals-cli-distrib.zip -d /tmp/petals-cli-distrib-zip && \
+  cp -r /tmp/petals-cli-distrib-zip/petals-cli-distrib-zip-*/* /opt/petals-deployer && \
+  rm -rf /tmp/petals-cli-distrib* && \
+  chmod -R 775 /opt/petals-deployer/ && \
+  apk del .bootstrap-deps wget ca-certificates && \
+  rm -rf /var/cache/apk/*
+
+# Set the working directory
+WORKDIR /opt/petals-deployer
+
+# Indicate the default script
+CMD /opt/petals-deployer/docker-wrapper.sh 

--- a/docker-wrapper.sh
+++ b/docker-wrapper.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+# Variables setting
+cli_host=`hostname -i`
+
+petals_host="localhost"
+petals_port="7700"
+petals_user="petals"
+petals_pass="petals"
+
+[ ! -z "$CLI_PETALS_HOST" ] && petals_host="$CLI_PETALS_HOST"
+[ ! -z "$CLI_PETALS_PORT" ] && petals_port="$CLI_PETALS_PORT"
+[ ! -z "$CLI_PETALS_USER" ] && petals_user="$CLI_PETALS_USER"
+[ ! -z "$CLI_PETALS_PASS" ] && petals_pass="$CLI_PETALS_PASS"
+
+petalscli="/opt/petals-deployer/bin/petals-cli.sh -h $petals_host -n $petals_port -u $petals_user -p $petals_pass -y -c "
+
+# Informational dump
+echo "############################ PETALS DEPLOYER ############################"
+echo "###     Starting deploy script with following parameters:" 
+echo " - Petals host: $petals_host" && echo " - Petals port: $petals_port" && echo " - Petals user: $petals_user" && echo " - Petals pass: $petals_pass"
+echo " - Deploy file: $DEPLOY_FILE"
+echo " - URLS to deploy: $DEPLOY_URLS"
+echo " - CLI host: $cli_host"
+echo " - CLI version :"
+/opt/petals-deployer/bin/petals-cli.sh --version
+
+# CLI environment file setting
+echo
+echo "###     Setting configuration..." 
+echo "#docker-petals-deployer artifacts server configuration" >> /opt/petals-deployer/conf/petals-cli.default 
+echo "embedded.http.port=80" >> /opt/petals-deployer/conf/petals-cli.default 
+echo "embedded.http.host=$cli_host" >> /opt/petals-deployer/conf/petals-cli.default
+echo >> /opt/petals-deployer/conf/petals-cli.default 
+
+# Pre deploy Petals ESB informations & status
+echo
+echo "###     Target Petals ESB container status:"
+echo
+$petalscli version
+$petalscli topology-list
+echo "Artifacts :"
+$petalscli list
+echo
+$petalscli endpoint-list
+
+echo
+echo "###     Starting deploy ..."
+
+# Deploy artifacts from urls
+if [ ! -z ${DEPLOY_URLS+x} ] && [ "$DEPLOY_URLS" != "" ] 
+then
+  echo
+  echo "# URLs found, deploying:"
+  IFSBACKUP="$IFS"
+  IFS=';'
+  set $DEPLOY_URLS
+  IFS="$IFSBACKUP"
+  for item in $*
+  do
+    echo "Deploying $item..."
+    $petalscli deploy -- -u $item
+  done
+  echo "# URLs deploy over."
+fi
+
+# Deploy artifacts from file
+if [ ! -z ${DEPLOY_FILE+x} ] && [ "$DEPLOY_FILE" != "" ] 
+then
+  echo
+  echo "# File found, deploying:"
+  while IFS='' read -r line || [[ -n "$line" ]]; do
+    echo "Deploying $line..."
+    $petalscli deploy -- -u $line
+  done < "$DEPLOY_FILE"
+  echo "# Files deploy over."
+fi
+
+# Post deploy Petals ESB status
+echo
+echo "###     Status after deploy:"
+echo
+echo "Artifacts :"
+$petalscli list
+echo
+$petalscli endpoint-list
+echo
+echo "###     Deploy script over."
+echo "#########################################################################"


### PR DESCRIPTION
Dockerfile and script allowing to 
- set default configuration parameters, file name and URL list at build
- build with CLI version selection
- set/override configuration parameters, file name (with a volume) and URL list at build
- deploy

Based on Alpine (final size 90MB)
CLI host is inferred at runtime, running in "--net:host" seems broken, needs investigation.
File separator for URLs changed to ";" due to shell script limitations.

Related to #1  #3  